### PR TITLE
Add FastAPI endpoint for embedding requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,98 @@ A wrapper that can imitate forward gateway and make call use liulianmao
 2. 为了对内容进行审计，需要更详细的日志
 3. 需要对模型的名称或请求地址进行映射
 4. 需要对模型的请求方法进行处理
+
+## Usage Instructions
+
+### Setting Up and Running the FastAPI Server
+
+1. Install the required dependencies:
+   ```bash
+   pip install fastapi zhipuai
+   ```
+
+2. Create a file named `main.py` and add the following code:
+   ```python
+   from fastapi import FastAPI, Request, HTTPException
+   from zhipuai import ZhipuAI
+
+   app = FastAPI()
+   client = ZhipuAI(api_key="your api key")
+
+   @app.post("/embedding")
+   async def create_embedding(request: Request):
+       try:
+           body = await request.json()
+           model = body.get("model")
+           input_text = body.get("input")
+
+           # Remap model names if necessary
+           model_mapping = {
+               "gpt-3-turbo": "glm-4"
+           }
+           if model in model_mapping:
+               model = model_mapping[model]
+
+           response = client.embeddings.create(
+               model=model,
+               input=input_text,
+           )
+           return response
+       except Exception as e:
+           raise HTTPException(status_code=500, detail=str(e))
+   ```
+
+3. Run the FastAPI server:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+### Example Requests and Responses
+
+#### Example Request
+
+```json
+{
+    "model": "gpt-3-turbo",
+    "input": "你好"
+}
+```
+
+#### Example Response
+
+```json
+{
+    "model": "glm-4",
+    "data": [
+        {
+            "embedding": [
+                -0.02675454691052437,
+                0.019060475751757622,
+                ...... 
+                -0.005519774276763201,
+                0.014949671924114227
+            ],
+            "index": 0,
+            "object": "embedding"
+        },
+        ...
+        {
+            "embedding": [
+                -0.02675454691052437,
+                0.019060475751757622,
+                ...... 
+                -0.005519774276763201,
+                0.014949671924114227
+            ],
+            "index": 2,
+            "object": "embedding"
+        }
+    ],
+    "object": "list",
+    "usage": {
+        "completion_tokens": 0,
+        "prompt_tokens": 100,
+        "total_tokens": 100
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # liulianmao-fastapi
-A wrapper that can imitate forward gateway and make call use liulianmao
+一个可以模仿转发网关并使用liulianmao进行调用的包装器
 
 
 这玩意是配合[liulianmao](https://github.com/LaoshuBaby/liulianmao)使用的。
@@ -13,22 +13,21 @@ A wrapper that can imitate forward gateway and make call use liulianmao
 3. 需要对模型的名称或请求地址进行映射
 4. 需要对模型的请求方法进行处理
 
-## Usage Instructions
+## 使用说明
 
-### Setting Up and Running the FastAPI Server
+### 设置和运行FastAPI服务器
 
-1. Install the required dependencies:
+1. 安装所需的依赖项:
    ```bash
-   pip install fastapi zhipuai
+   pip install fastapi liulianmao
    ```
 
-2. Create a file named `main.py` and add the following code:
+2. 创建一个名为`main.py`的文件，并添加以下代码:
    ```python
    from fastapi import FastAPI, Request, HTTPException
-   from zhipuai import ZhipuAI
+   from liulianmao import ask
 
    app = FastAPI()
-   client = ZhipuAI(api_key="your api key")
 
    @app.post("/embedding")
    async def create_embedding(request: Request):
@@ -44,23 +43,20 @@ A wrapper that can imitate forward gateway and make call use liulianmao
            if model in model_mapping:
                model = model_mapping[model]
 
-           response = client.embeddings.create(
-               model=model,
-               input=input_text,
-           )
+           response = ask(msg=input_text, model=model)
            return response
        except Exception as e:
            raise HTTPException(status_code=500, detail=str(e))
    ```
 
-3. Run the FastAPI server:
+3. 运行FastAPI服务器:
    ```bash
    uvicorn main:app --reload
    ```
 
-### Example Requests and Responses
+### 示例请求和响应
 
-#### Example Request
+#### 示例请求
 
 ```json
 {
@@ -69,7 +65,7 @@ A wrapper that can imitate forward gateway and make call use liulianmao
 }
 ```
 
-#### Example Response
+#### 示例响应
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # liulianmao-fastapi
 一个可以模仿转发网关并使用liulianmao进行调用的包装器
 
+## 芝士神马？
 
 这玩意是配合[liulianmao](https://github.com/LaoshuBaby/liulianmao)使用的。
 

--- a/README.md
+++ b/README.md
@@ -23,34 +23,7 @@ A wrapper that can imitate forward gateway and make call use liulianmao
    pip install fastapi liulianmao
    ```
 
-2. 创建一个名为`main.py`的文件，并添加以下代码:
-   ```python
-   from fastapi import FastAPI, Request, HTTPException
-   from liulianmao import ask
-
-   app = FastAPI()
-
-   @app.post("/embedding")
-   async def create_embedding(request: Request):
-       try:
-           body = await request.json()
-           model = body.get("model")
-           input_text = body.get("input")
-
-           # Remap model names if necessary
-           model_mapping = {
-               "gpt-3-turbo": "glm-4"
-           }
-           if model in model_mapping:
-               model = model_mapping[model]
-
-           response = ask(msg=input_text, model=model)
-           return response
-       except Exception as e:
-           raise HTTPException(status_code=500, detail=str(e))
-   ```
-
-3. 运行FastAPI服务器:
+2. 运行FastAPI服务器:
    ```bash
    uvicorn main:app --reload
    ```
@@ -62,7 +35,12 @@ A wrapper that can imitate forward gateway and make call use liulianmao
 ```json
 {
     "model": "gpt-3-turbo",
-    "input": "你好"
+    "messages": [
+        {
+            "role": "user",
+            "content": "你好"
+        }
+    ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # liulianmao-fastapi
-一个可以模仿转发网关并使用liulianmao进行调用的包装器
+A wrapper that can imitate forward gateway and make call use liulianmao
 
 ## 芝士神马？
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome</title>
+</head>
+<body>
+    <h1>Hello, user!</h1>
+    <p>Welcome to our service. We hope you have a great experience!</p>
+</body>
+</html>

--- a/src/main.py
+++ b/src/main.py
@@ -15,12 +15,16 @@ app = FastAPI()
 
 
 def forward_chat(request: Request):
-    # ask(msg="")
-    ans=ask(
-        msg="Hello can you tell me what's the girl are",
+    body = request.json()
+    model = body.get("model")
+    messages = body.get("messages")
+
+    ans = ask(
+        msg=messages[0]["content"],
         available_models=[],
-        model_series="zhipu",
-        image="",
+        model_series="openai",
+        no_history=False,
+        image_type="none",
     )
     return ans
 
@@ -42,8 +46,12 @@ def forward_embedding(request: Request):
 
 @app.get("/")
 async def hello():
-    # this need to be replaced with a html file, read it and response it
-    return "Hello, user!"
+    return FileResponse("src/index.html")
+
+
+@app.get("/hello")
+async def hello_route():
+    return FileResponse("src/index.html")
 
 
 @app.post("/paas/v1/chat/completions")

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,35 @@
 from fastapi import FastAPI, Request, HTTPException
-from zhipuai import ZhipuAI
+# from zhipuai import ZhipuAI
+
+const_model_mapping = {
+            "gpt-3-turbo": "glm-4"
+        }
 
 app = FastAPI()
-client = ZhipuAI(api_key="your api key")
+# client = ZhipuAI(api_key="your api key")
+
+def forward_chat():
+    pass
+
+def forward_embedding():
+    pass
+
+@app.get("/")
+async def hello():
+    # return a hello page from read index.html
+    pass
+
+@app.post("/paas/v1/chat/completions"):
+async def pass_v1_chat_completions():
+    forward()
+
+@app.post("/paas/v4/chat/completions"):
+async def pass_v4_chat_completions():
+    forward()
+
+# v1 and v4 that will call https://open.bigmodel.cn/api/paas/v4/embeddings
+
+# need to use forward_embedding
 
 @app.post("/embedding")
 async def create_embedding(request: Request):
@@ -12,16 +39,15 @@ async def create_embedding(request: Request):
         input_text = body.get("input")
 
         # Remap model names if necessary
-        model_mapping = {
-            "gpt-3-turbo": "glm-4"
-        }
-        if model in model_mapping:
-            model = model_mapping[model]
 
-        response = client.embeddings.create(
-            model=model,
-            input=input_text,
-        )
+        if model in const_model_mapping:
+            model = const_model_mapping[model]
+
+        # response = client.embeddings.create(
+        #     model=model,
+        #     input=input_text,
+        # )
+        response={}
         return response
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/main.py
+++ b/src/main.py
@@ -15,18 +15,14 @@ app = FastAPI()
 
 
 def forward_chat(request: Request):
-    try:
-        body = request.json()
-        model = body.get("model")
-        input_text = body.get("input")
-
-        if model in const_model_mapping:
-            model = const_model_mapping[model]
-
-        response = ask(msg=input_text, model=model)
-        return response
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    # ask(msg="")
+    ans=ask(
+        msg="Hello can you tell me what's the girl are",
+        available_models=[],
+        model_series="zhipu",
+        image="",
+    )
+    return ans
 
 
 def forward_embedding(request: Request):

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, Request, HTTPException
+from zhipuai import ZhipuAI
+
+app = FastAPI()
+client = ZhipuAI(api_key="your api key")
+
+@app.post("/embedding")
+async def create_embedding(request: Request):
+    try:
+        body = await request.json()
+        model = body.get("model")
+        input_text = body.get("input")
+
+        # Remap model names if necessary
+        model_mapping = {
+            "gpt-3-turbo": "glm-4"
+        }
+        if model in model_mapping:
+            model = model_mapping[model]
+
+        response = client.embeddings.create(
+            model=model,
+            input=input_text,
+        )
+        return response
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/main.py
+++ b/src/main.py
@@ -1,53 +1,52 @@
 from fastapi import FastAPI, Request, HTTPException
-# from zhipuai import ZhipuAI
+from liulianmao import ask
 
 const_model_mapping = {
             "gpt-3-turbo": "glm-4"
         }
 
 app = FastAPI()
-# client = ZhipuAI(api_key="your api key")
 
-def forward_chat():
-    pass
-
-def forward_embedding():
-    pass
-
-@app.get("/")
-async def hello():
-    # return a hello page from read index.html
-    pass
-
-@app.post("/paas/v1/chat/completions"):
-async def pass_v1_chat_completions():
-    forward()
-
-@app.post("/paas/v4/chat/completions"):
-async def pass_v4_chat_completions():
-    forward()
-
-# v1 and v4 that will call https://open.bigmodel.cn/api/paas/v4/embeddings
-
-# need to use forward_embedding
-
-@app.post("/embedding")
-async def create_embedding(request: Request):
+def forward_chat(request: Request):
     try:
-        body = await request.json()
+        body = request.json()
         model = body.get("model")
         input_text = body.get("input")
-
-        # Remap model names if necessary
 
         if model in const_model_mapping:
             model = const_model_mapping[model]
 
-        # response = client.embeddings.create(
-        #     model=model,
-        #     input=input_text,
-        # )
-        response={}
+        response = ask(msg=input_text, model=model)
         return response
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+def forward_embedding(request: Request):
+    try:
+        body = request.json()
+        model = body.get("model")
+        input_text = body.get("input")
+
+        if model in const_model_mapping:
+            model = const_model_mapping[model]
+
+        response = ask(msg=input_text, model=model)
+        return response
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/")
+async def hello():
+    return "Hello, user!"
+
+@app.post("/paas/v1/chat/completions")
+async def pass_v1_chat_completions(request: Request):
+    return forward_chat(request)
+
+@app.post("/paas/v4/chat/completions")
+async def pass_v4_chat_completions(request: Request):
+    return forward_chat(request)
+
+@app.post("/embedding")
+async def create_embedding(request: Request):
+    return forward_embedding(request)

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,18 @@
-from fastapi import FastAPI, Request, HTTPException
+import uvicorn
+from fastapi import FastAPI, HTTPException, Path, Request
+from fastapi.responses import FileResponse, HTMLResponse
 from liulianmao import ask
 
+
 const_model_mapping = {
-            "gpt-3-turbo": "glm-4"
-        }
+    "gpt-3-turbo": "glm-4",
+    "gpt-4": "glm-4-0520",
+    "gpt-4o": "glm-4v",
+    "text-embedding-ada-002": "embedding-3",
+}
 
 app = FastAPI()
+
 
 def forward_chat(request: Request):
     try:
@@ -21,6 +28,7 @@ def forward_chat(request: Request):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 def forward_embedding(request: Request):
     try:
         body = request.json()
@@ -35,18 +43,27 @@ def forward_embedding(request: Request):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @app.get("/")
 async def hello():
+    # this need to be replaced with a html file, read it and response it
     return "Hello, user!"
+
 
 @app.post("/paas/v1/chat/completions")
 async def pass_v1_chat_completions(request: Request):
     return forward_chat(request)
 
+
 @app.post("/paas/v4/chat/completions")
 async def pass_v4_chat_completions(request: Request):
     return forward_chat(request)
 
+
 @app.post("/embedding")
 async def create_embedding(request: Request):
     return forward_embedding(request)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=9000)


### PR DESCRIPTION
Add FastAPI implementation to accept OpenAI embedding requests and forward them to the Zhipu API with model name remapping.

* **src/main.py**
  - Import necessary modules: `FastAPI`, `Request`, `HTTPException`, `ZhipuAI`.
  - Initialize FastAPI app and ZhipuAI client.
  - Define a POST endpoint `/embedding` to accept OpenAI embedding requests.
  - Implement logic to remap model names and forward requests to Zhipu API.
  - Handle and return the response from Zhipu API.

* **README.md**
  - Add a section explaining how to use the new FastAPI endpoint.
  - Provide example requests and responses.
  - Include instructions on how to set up and run the FastAPI server.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LaoshuBaby/liulianmao-fastapi?shareId=15a17897-c59b-45a2-9b8c-eb50cb7c9037).